### PR TITLE
Updated to show only latest stable releases.

### DIFF
--- a/plugins/content/arslatest/arslatest.php
+++ b/plugins/content/arslatest/arslatest.php
@@ -143,6 +143,7 @@ class plgContentArslatest extends JPlugin
 		$model = $container->factory->model('Releases')->tmpInstance();
 		$model->reset(true)
 		      ->published(1)
+		      ->maturity(stable)
 		      ->latest(true)
 		      ->access_user($container->platform->getUser()->id)
 		      ->with(['items', 'category']);


### PR DESCRIPTION
Was showing any latest release earlier. This fix ensures only stable releases are shown. Might want to consider passing a flag in the content plugin text to make this based on a specific condition of stability.
